### PR TITLE
Added tech categories to equipment bonuses in traits

### DIFF
--- a/Config/common/traits.cwt
+++ b/Config/common/traits.cwt
@@ -51,6 +51,14 @@ country_leader_trait = {
 			alias_name[air_stat] = alias_match_left[air_stat]
 		}
 		## cardinality = 0..inf
+		enum[tech_category] = {
+			## cardinality = 0..1
+			instant = bool
+			alias_name[unit_stat] = alias_match_left[unit_stat]
+			alias_name[naval_stat] = alias_match_left[naval_stat]
+			alias_name[air_stat] = alias_match_left[air_stat]
+		}
+		## cardinality = 0..inf
 		enum[unit_types] = {
 			## cardinality = 0..1
 			instant = bool


### PR DESCRIPTION
Equipment bonuses can also apply to tech categories. This fixes that.

For example this was marked as an error before (mind the horrible naming convention):
```
Cat_NAVAL_EQP_1 = { equipment_bonus = { Cat_NAVAL_EQP = { naval_speed = 0.015 naval_range = 0.015 surface_visibility = -0.015 } } }
Cat_NAVAL_EQP_2 = { equipment_bonus = { Cat_NAVAL_EQP = { naval_speed = 0.03 naval_range = 0.03 surface_visibility = -0.03 } } }
Cat_INF_1 = { equipment_bonus = { Cat_INF = { reliability = 0.015  } } }
```