### PR TITLE
It seems that if you crate a unit leader with no traits bracket, the …

### DIFF
--- a/Config/effects.cwt
+++ b/Config/effects.cwt
@@ -517,9 +517,9 @@ alias[effect:create_navy_leader] = {
 	## cardinality = 0..1
 	## severity = warning
 	gfx = <spriteType>
-	## cardinality = 0..1
+	## cardinality = 1..1
 	traits = {
-		## cardinality = ~1..inf
+		## cardinality = 0..inf
 		<unit_leader_trait>
 	}
 	## cardinality = ~1..1
@@ -1129,9 +1129,9 @@ alias[effect:create_field_marshal] = {
 	## cardinality = 0..1
 	## severity = warning
 	gfx = <spriteType>
-	## cardinality = 0..1
+	## cardinality = 1..1
 	traits = {
-		## cardinality = ~1..inf
+		## cardinality = 0..inf
 		<unit_leader_trait>
 	}
 	## cardinality = ~1..1
@@ -1164,9 +1164,9 @@ alias[effect:create_corps_commander] = {
 	## cardinality = 0..1
 	## severity = warning
 	gfx = <spriteType>
-	## cardinality = 0..1
+	## cardinality = 1..1
 	traits = {
-		## cardinality = ~1..inf
+		## cardinality = 0..inf
 		<unit_leader_trait>
 	}
 	## cardinality = ~1..1

--- a/Config/effects.cwt
+++ b/Config/effects.cwt
@@ -517,6 +517,7 @@ alias[effect:create_navy_leader] = {
 	## cardinality = 0..1
 	## severity = warning
 	gfx = <spriteType>
+	### Sets starting traits for this leader. If empty, sets no traits. If missing, assigns a random trait
 	## cardinality = 1..1
 	traits = {
 		## cardinality = 0..inf
@@ -1129,6 +1130,7 @@ alias[effect:create_field_marshal] = {
 	## cardinality = 0..1
 	## severity = warning
 	gfx = <spriteType>
+	### Sets starting traits for this leader. If empty, sets no traits. If missing, assigns a random trait
 	## cardinality = 1..1
 	traits = {
 		## cardinality = 0..inf
@@ -1164,6 +1166,7 @@ alias[effect:create_corps_commander] = {
 	## cardinality = 0..1
 	## severity = warning
 	gfx = <spriteType>
+	### Sets starting traits for this leader. If empty, sets no traits. If missing, assigns a random trait
 	## cardinality = 1..1
 	traits = {
 		## cardinality = 0..inf

--- a/Config/history/oobs.cwt
+++ b/Config/history/oobs.cwt
@@ -179,6 +179,7 @@ oob = {
 		}
 		## cardinality = 0..1
 		gfx = scalar
+		### Sets starting traits for this leader. If empty, sets no traits. If missing, assigns a random trait
 		## cardinality = 1..1
 		traits = {
 			## cardinality = 0..inf
@@ -218,6 +219,7 @@ oob = {
 		}
 		## cardinality = 0..1
 		gfx = scalar
+		### Sets starting traits for this leader. If empty, sets no traits. If missing, assigns a random trait
 		## cardinality = 1..1
 		traits = {
 			## cardinality = 0..inf
@@ -260,6 +262,7 @@ oob = {
 		
 		## cardinality = 0..1
 		gfx = scalar
+		### Sets starting traits for this leader. If empty, sets no traits. If missing, assigns a random trait
 		## cardinality = 1..1
 		traits = {
 			## cardinality = 0..inf

--- a/Config/history/oobs.cwt
+++ b/Config/history/oobs.cwt
@@ -179,9 +179,9 @@ oob = {
 		}
 		## cardinality = 0..1
 		gfx = scalar
-		## cardinality = 0..1
+		## cardinality = 1..1
 		traits = {
-			## cardinality = ~1..inf
+			## cardinality = 0..inf
 			<unit_leader_trait>
 		}
 		## cardinality = ~1..1
@@ -218,9 +218,9 @@ oob = {
 		}
 		## cardinality = 0..1
 		gfx = scalar
-		## cardinality = 0..1
+		## cardinality = 1..1
 		traits = {
-			## cardinality = ~1..inf
+			## cardinality = 0..inf
 			<unit_leader_trait>
 		}
 		## cardinality = ~1..1
@@ -260,9 +260,9 @@ oob = {
 		
 		## cardinality = 0..1
 		gfx = scalar
-		## cardinality = 0..1
+		## cardinality = 1..1
 		traits = {
-			## cardinality = ~1..inf
+			## cardinality = 0..inf
 			<unit_leader_trait>
 		}
 		## cardinality = ~1..1


### PR DESCRIPTION
…game will auto assign one. This means that you should *always* have a traits bracket, which *is* valid to be empty. Need someone to double check as this seems pretty odd, and I'm amazed no-one noticed before now.