### PR TITLE
Added "Battle for the Bosporus" to enum[dlc]

### DIFF
--- a/Config/shared_enums.cwt
+++ b/Config/shared_enums.cwt
@@ -6,6 +6,7 @@ enums = {
 		"Waking the Tiger"
 		"Man the Guns"
 		"La Resistance"
+		"Battle for the Bosporus"
 	}
 
 	enum[hours_days_months] = {


### PR DESCRIPTION
Added the latest DLC to the enum[dlc] this should stop it from having it raise an error.