### PR TITLE
Added short form of add_resistance_target

### DIFF
--- a/Config/effects_new.cwt
+++ b/Config/effects_new.cwt
@@ -423,6 +423,9 @@ alias[effect:every_occupied_country] = {
 
 ###Adds resistance target to the scoped state.
 ## scopes = { STATE }
+alias[effect:add_resistance_target] = variable_field
+###Adds resistance target to the scoped state.
+## scopes = { STATE }
 alias[effect:add_resistance_target] = {
 	amount = variable_field
 	## cardinality = ~0..1


### PR DESCRIPTION
`add_resistance_target = 30` is the valid short form, but not recognized by cwtools.
This PR should fix it,